### PR TITLE
add guidance for new minimum explainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ or archival if we decide an explainer is no longer worth pursuing.
 
 For new minimum explainers (with sections 1-5 or fewer):
 * iterate promptly with PRs adding sections up through 6 within 2-4 weeks of publishing your minimum explainer
-* create (at least) one new PR for each section added and request a repo owner review/approval and merge accordingly
+* create a PR with at least one additional section and request a repo owner review/approval and merge accordingly
 * start drafting additional PRs for sections up through 10
 
 When ready to solicit external feedback on an explainer:

--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ This repo is for developing explainer files until ready for external feedback,
 or archival if we decide an explainer is no longer worth pursuing.
 
 For new minimum explainers (with sections 1-5 or fewer):
-* iterate promptly with PRs adding sections up through 6 within 2-4 weeks of publishing your minimum explainer
-* create a PR with at least one additional section and request a repo owner review/approval and merge accordingly
-* start drafting additional PRs for sections up through 10
+* iterate promptly with one or more PRs to add sections up through 6 within 2-4 weeks of publishing your minimum explainer
 
 When ready to solicit external feedback on an explainer:
 * create a new repo for the explainer (same short-name if possible), 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Expand your explainer with the following sections, in order:
 This repo is for developing explainer files until ready for external feedback, 
 or archival if we decide an explainer is no longer worth pursuing.
 
+For new minimum explainers (with sections 1-5 or fewer):
+* iterate promptly with PRs adding sections up through 6 within 2-4 weeks of publishing your minimum explainer
+* create (at least) one new PR for each section added and request a repo owner review/approval and merge accordingly
+* start drafting additional PRs for sections up through 10
+
 When ready to solicit external feedback on an explainer:
 * create a new repo for the explainer (same short-name if possible), 
 * move the explainer file into that new repo (with history)

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ Expand your explainer with the following sections, in order:
 This repo is for developing explainer files until ready for external feedback, 
 or archival if we decide an explainer is no longer worth pursuing.
 
-For new minimum explainers (with sections 1-5 or fewer):
-* iterate promptly with one or more PRs to add sections up through 6 within 2-4 weeks of publishing your minimum explainer
+For new minimum explainers (those missing any of sections 2 through 6),
+we expect that those sections are added within 2-4 weeks of
+publishing your minimum explainer, using pull requests.
 
 When ready to solicit external feedback on an explainer:
 * create a new repo for the explainer (same short-name if possible), 


### PR DESCRIPTION
Explicit guidance for new minimum explainers (with sections 1-5 or fewer) for promptly expanding through section 6