### PR TITLE
examples in Abandoning or replacing or migrating an explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Please [archive](https://github.com/mozilla/explainers/tree/main/archive) an exp
 * we write a new explainer with a different problem framing that supersedes the explainer, and link from it to the new explainer
 * an explainer by another organization incorporates our explainer, and we link from ours to the external explainer
 
+Please add a link to the archived explainer to point to the work that replaces it, or to briefly document why it is abandoned.
+
 ## Explainer repo progress
 Iterate on an explainer repo, improving the explainer 
 until there is broader interest to migrate it to an incubation or standardization group, 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ When ready to solicit external feedback on an explainer:
 * add a link to the new repo in the Current Explainers section
 
 ## Abandoning or replacing or migrating an explainer
-Please [archive](https://github.com/mozilla/explainers/tree/main/archive) an explainer if:
+Please [archive](https://github.com/mozilla/explainers/tree/main/archive) an explainer when any one of these occurs:
+* it’s incorporated into an incubation (e.g. W3C CG) or standardization destination (e.g. W3C WG, or Stage 1 in TC39 or WHATWG)
 * we decide the problem isn’t worth solving, or is better solved some other way, and document why in the explainer
 * we write a new explainer with a different problem framing that supersedes the explainer, and link from it to the new explainer
-* an explainer by another organization incorporates our explainer, and we link from it to the external explainer
-* the explainer has been incorporated into an incubation or standardization destination 
+* an explainer by another organization incorporates our explainer, and we link from ours to the external explainer
 
 ## Explainer repo progress
 Iterate on an explainer repo, improving the explainer 


### PR DESCRIPTION
update Abandoning or replacing or migrating an explainer
* clarify any one of these happen
* move incorporation into a destination to the top (most desired reason, expected to be most common), and provide examples of incubation and standardization destinations, including Stage 1 for TC39 or WHATWG to clarify for folks developing explainers for those destinations
* slight wording tweak for clarity on another point